### PR TITLE
Fixing issues with the mmc-packgen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val env = System.getenv()
 version = if (env["SNAPSHOTS_URL"] != null) {
 	"0-SNAPSHOT"
 } else {
-	"0.9.0"
+	"0.9.1"
 }
 base.archivesBaseName = project.name
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ repositories {
 
 dependencies {
 	implementation("org.quiltmc.parsers:json:0.2.1")
-	implementation("com.vdurmont:semver4j:3.1.0")
 	compileOnly("org.jetbrains:annotations:20.1.0")
 }
 
@@ -72,7 +71,6 @@ tasks.jar {
 
 tasks.shadowJar {
 	relocate("org.quiltmc.parsers.json", "org.quiltmc.installer.lib.parsers.json")
-	relocate("com.vdurmont:semver4j","org.quiltmc.installer.lib.test.semvar")
 	minimize()
 
 	// Compiler does not know which set method we are targeting with null value

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ repositories {
 
 dependencies {
 	implementation("org.quiltmc.parsers:json:0.2.1")
+	implementation("com.vdurmont:semver4j:3.1.0")
 	compileOnly("org.jetbrains:annotations:20.1.0")
 }
 
@@ -71,6 +72,7 @@ tasks.jar {
 
 tasks.shadowJar {
 	relocate("org.quiltmc.parsers.json", "org.quiltmc.installer.lib.parsers.json")
+	relocate("com.vdurmont:semver4j","org.quiltmc.installer.lib.test.semvar")
 	minimize()
 
 	// Compiler does not know which set method we are targeting with null value

--- a/src/main/java/org/quiltmc/installer/CliInstaller.java
+++ b/src/main/java/org/quiltmc/installer/CliInstaller.java
@@ -147,7 +147,7 @@ public final class CliInstaller {
 					return Action.DISPLAY_HELP;
 				}
 
-				String intermediary = fetchIntermediary(minecraftVersion);
+				String intermediary = fetchIntermediary(GameSide.CLIENT, minecraftVersion);
 
 				// At this point all the require arguments have been parsed
 				if (split.size() == 0) {
@@ -332,9 +332,11 @@ public final class CliInstaller {
 		}
 	}
 
-	private static String fetchIntermediary(String minecraftVersion) {
+	private static String fetchIntermediary(GameSide side, String minecraftVersion) {
 		return OrnitheMeta.create(OrnitheMeta.ORNITHE_META_URL, Set.of(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT)).thenApply(meta -> {
-			return meta.getEndpoint(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT).get(minecraftVersion);
+			VersionManifest manifest = VersionManifest.create().join();
+			VersionManifest.Version version = manifest.getVersion(minecraftVersion);
+			return meta.getEndpoint(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT).get(version.id(side));
 		}).join();
 	}
 

--- a/src/main/java/org/quiltmc/installer/CliInstaller.java
+++ b/src/main/java/org/quiltmc/installer/CliInstaller.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.installer.action.Action;
@@ -146,9 +147,11 @@ public final class CliInstaller {
 					return Action.DISPLAY_HELP;
 				}
 
+				String intermediary = fetchIntermediary(minecraftVersion);
+
 				// At this point all the require arguments have been parsed
 				if (split.size() == 0) {
-					return Action.installClient(minecraftVersion, launcherType, loaderType, null, null, false);
+					return Action.installClient(minecraftVersion, launcherType, loaderType, null, intermediary, null, false);
 				}
 
 				// Try to parse loader version first
@@ -163,7 +166,7 @@ public final class CliInstaller {
 
 				// No more arguments, just loader version
 				if (split.size() == 0) {
-					return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, null, false);
+					return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, null, false);
 				}
 
 				// There are some additional options
@@ -221,7 +224,7 @@ public final class CliInstaller {
 					}
 				}
 
-				return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, options.get("--install-dir"), !options.containsKey("--no-profile"));
+				return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, options.get("--install-dir"), !options.containsKey("--no-profile"));
 			}
 			case "server": {
 				if (split.size() < 1) {
@@ -327,6 +330,12 @@ public final class CliInstaller {
 			System.err.printf("Invalid argument \"%s\"%n", arg);
 			return Action.DISPLAY_HELP;
 		}
+	}
+
+	private static String fetchIntermediary(String minecraftVersion) {
+		return OrnitheMeta.create(OrnitheMeta.ORNITHE_META_URL, Set.of(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT)).thenApply(meta -> {
+			return meta.getEndpoint(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT).get(minecraftVersion);
+		}).join();
 	}
 
 	/**

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -89,7 +89,7 @@ public final class LaunchJson {
 											combinedCombination += gameArgument + " ";
 										}
 									}
-									vanilaMap.put("minecraftArguements", combinedCombination.trim());
+									vanilaMap.put("minecraftArguments", combinedCombination.trim());
 								}
 							}
 

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -38,14 +38,6 @@ public final class LaunchJson {
 				vanillaJson ->  {
 					try {
 						Map<String, Object> vanilaMap = (Map<String, Object>) Gsons.read(JsonReader.json(vanillaJson));
-						List<Map<String, String>> vanillaLibraries = (List<Map<String, String>>) vanilaMap.get("libraries");
-
-						vanillaLibraries.removeIf(lib -> {
-							String name = lib.get("name");
-							return name.contains("org.ow2.asm") || name.contains("org.lwjgl");
-						});
-
-						vanilaMap.put("libraries", vanillaLibraries);
 
 						String clientName = "com.mojang:minecraft:" + gameVersion.id() + ":client";
 						Map<String,Map<String, String>> downloads = (Map<String, Map<String, String>>) vanilaMap.get("downloads");
@@ -55,32 +47,19 @@ public final class LaunchJson {
 								"downloads", Map.of("artifact",client),
 								"name",clientName
 						);
-						vanilaMap.put("mainJar", mainJar);
 
-						vanilaMap.put("name", "Minecraft");
-						vanilaMap.put("uid", "net.minecraft");
-						vanilaMap.put("version", gameVersion.id());
-						vanilaMap.put("compatibleJavaMajors", List.of(8)); // not all versions have this defined in manifests and even betas use 8
-						vanilaMap.put("format", 1);
+						List<Map<String, String>> vanillaLibraries = (List<Map<String, String>>) vanilaMap.get("libraries");
+						vanillaLibraries.removeIf(lib -> {
+							String name = lib.get("name");
+							return name.contains("org.ow2.asm") || name.contains("org.lwjgl");
+						});
 
-						vanilaMap.remove("downloads");
-						vanilaMap.remove("javaVersion");
-						vanilaMap.remove("id");
-						vanilaMap.remove("time");
-						vanilaMap.remove("logging");
-						vanilaMap.remove("minimumLauncherVersion");
-						vanilaMap.remove("complianceLevel");
-
+						List<String> traits = new ArrayList<>();
 						if (((String) vanilaMap.get("mainClass")).contains("launchwrapper")) {
-							vanilaMap.put("+traits", List.of("texturepacks"));
+							traits.add("texturepacks");
 						}
-						vanilaMap.put("requires",List.of(
-								Map.of(
-										"suggests", "${lwjgl_version}",
-										"uid", "${lwjgl_uid}"
-								)
-						));
 
+						String minecraftArguments = (String) vanilaMap.getOrDefault("minecraftArguments", "");
 						if (vanilaMap.containsKey("arguments")) {
 							Map<String, Object> arguments =  ((Map<String, Object>) vanilaMap.get("arguments"));//.get("game");
 
@@ -94,17 +73,21 @@ public final class LaunchJson {
 											combinedCombination += gameArgument + " ";
 										}
 									}
-									vanilaMap.put("minecraftArguments", combinedCombination.trim());
+									minecraftArguments = combinedCombination.trim();
 									// TODO this is bit of a hack? ideally should derive this from the jvm args list of the arguments object,
 									//  but every version that has a game arguments list has this trait so unless manifests change this works
-									vanilaMap.put("+traits", List.of("FirstThreadOnMacOS"));
+									traits.add("FirstThreadOnMacOS");
 								}
 							}
-							vanilaMap.remove("arguments");
 						}
 
 						StringWriter writer = new StringWriter();
-						Gsons.write(JsonWriter.json(writer), vanilaMap);
+						Gsons.write(
+								JsonWriter.json(writer),
+								buildPackJsonMap(
+										vanilaMap, vanillaLibraries, minecraftArguments, traits, mainJar, gameVersion.id()
+								)
+						);
 
 						return writer.toString();
 					} catch (IOException e) {
@@ -112,6 +95,43 @@ public final class LaunchJson {
 					}
 				}
 		);
+	}
+
+
+	private static Map<String, Object> buildPackJsonMap(
+			Map<String, Object> vanilaMap,
+			List<Map<String, String>> modifiedLibraries,
+			String minecraftArguments,
+			List<String> traits,
+			Map<String, Object> mainJar,
+			String gameVersion
+	){
+		Map<String, Object> moddedJsonMap = new LinkedHashMap<>();
+
+		if(!traits.isEmpty()){
+			moddedJsonMap.put("+traits",traits);
+		}
+
+		moddedJsonMap.put("assetIndex",vanilaMap.get("assetIndex"));
+		moddedJsonMap.put("compatibleJavaMajors", List.of(8));
+		moddedJsonMap.put("formatVersion", 1);
+		moddedJsonMap.put("libraries", modifiedLibraries);
+		moddedJsonMap.put("mainClass", vanilaMap.get("mainClass"));
+		moddedJsonMap.put("mainJar", mainJar);
+		moddedJsonMap.put("minecraftArguments", minecraftArguments);
+		moddedJsonMap.put("name", "Minecraft");
+		moddedJsonMap.put("releaseTime", vanilaMap.get("releaseTime"));
+		moddedJsonMap.put("requires",List.of(
+				Map.of(
+						"suggests", "${lwjgl_version}",
+						"uid", "${lwjgl_uid}"
+				)
+		));
+		moddedJsonMap.put("type", vanilaMap.get("type"));
+		moddedJsonMap.put("uid", "net.minecraft");
+		moddedJsonMap.put("version", gameVersion);
+
+		return moddedJsonMap;
 	}
 
 	/**

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -35,9 +35,9 @@ public final class LaunchJson {
 	@SuppressWarnings("unchecked")
 	public static CompletableFuture<String> getMmcJson(VersionManifest.Version gameVersion){
 		return LaunchJson.get(gameVersion).thenApply(
-				vanilaJson ->  {
+				vanillaJson ->  {
 					try {
-						Map<String, Object> vanilaMap = (Map<String, Object>) Gsons.read(JsonReader.json(vanilaJson));
+						Map<String, Object> vanilaMap = (Map<String, Object>) Gsons.read(JsonReader.json(vanillaJson));
 						List<Map<String, String>> vanillaLibraries = (List<Map<String, String>>) vanilaMap.get("libraries");
 
 						vanillaLibraries.removeIf(lib -> {
@@ -47,7 +47,7 @@ public final class LaunchJson {
 
 						vanilaMap.put("libraries", vanillaLibraries);
 
-						String clientName = "com.mojang:minecraft:" + gameVersion.id() + "client";
+						String clientName = "com.mojang:minecraft:" + gameVersion.id() + ":client";
 						Map<String,Map<String, String>> downloads = (Map<String, Map<String, String>>) vanilaMap.get("downloads");
 						Map<String, String> client = downloads.get("client");
 
@@ -57,14 +57,19 @@ public final class LaunchJson {
 						);
 						vanilaMap.put("mainJar", mainJar);
 
+						vanilaMap.put("name", "Minecraft");
 						vanilaMap.put("uid", "net.minecraft");
 						vanilaMap.put("version", gameVersion.id());
 						vanilaMap.put("compatibleJavaMajors", List.of(8)); // not all versions have this defined in manifests and even betas use 8
+						vanilaMap.put("format", 1);
 
 						vanilaMap.remove("downloads");
 						vanilaMap.remove("javaVersion");
 						vanilaMap.remove("id");
 						vanilaMap.remove("time");
+						vanilaMap.remove("logging");
+						vanilaMap.remove("minimumLauncherVersion");
+						vanilaMap.remove("complianceLevel");
 
 						if (((String) vanilaMap.get("mainClass")).contains("launchwrapper")) {
 							vanilaMap.put("+traits", List.of("texturepacks"));
@@ -90,9 +95,12 @@ public final class LaunchJson {
 										}
 									}
 									vanilaMap.put("minecraftArguments", combinedCombination.trim());
+									// TODO this is bit of a hack? ideally should derive this from the jvm args list of the arguments object,
+									//  but every version that has a game arguments list has this trait so unless manifests change this works
+									vanilaMap.put("+traits", List.of("FirstThreadOnMacOS"));
 								}
 							}
-
+							vanilaMap.remove("arguments");
 						}
 
 						StringWriter writer = new StringWriter();

--- a/src/main/java/org/quiltmc/installer/MmcPackCreator.java
+++ b/src/main/java/org/quiltmc/installer/MmcPackCreator.java
@@ -16,6 +16,9 @@
 
 package org.quiltmc.installer;
 
+import org.quiltmc.parsers.json.JsonReader;
+import org.quiltmc.parsers.json.JsonToken;
+
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
@@ -24,15 +27,11 @@ import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.quiltmc.parsers.json.JsonReader;
-import org.quiltmc.parsers.json.JsonToken;
-import com.vdurmont.semver4j.*;
-
 public class MmcPackCreator {
 	private static final String ENV_WRAPPER_COMMAND = "WrapperCommand=\"env __GL_THREADED_OPTIMIZATIONS=0\"";
 	private static final boolean IS_LINUX_LIKE_OS;
-	private static final Semver VERSION_1_6 = new Semver("1.6.0-pre+06251516");
-	private static final Semver VERSION_1_3 = new Semver("1.3.0-pre+07261249");
+	//private static final Semver VERSION_1_6 = new Semver("1.6.0-pre+06251516");
+	//private static final Semver VERSION_1_3 = new Semver("1.3.0-pre+07261249");
 
 	private static String findLwjglVersion(VersionManifest manifest, String gameVersion) {
 		for (String rawUrl : manifest.getVersion(gameVersion).details().manifests()) {
@@ -129,38 +128,41 @@ public class MmcPackCreator {
 				.replaceAll("\\$\\{lwjgl_uid}", lwjglMajorVer.equals("3") ? "org.lwjgl3" : "org.lwjgl");
 	}
 
+	private static String transformMinecraftJson(String minecraftPatchString, String lwjglVersion) {
+		String lwjglMajorVer = lwjglVersion.substring(0,1);
+		return minecraftPatchString
+				.replaceAll("\\$\\{lwjgl_version}", lwjglVersion)
+				.replaceAll("\\$\\{lwjgl_uid}", lwjglMajorVer.equals("3") ? "org.lwjgl3" : "org.lwjgl");
+	}
+
 	public static void compileMmcZip(File outPutDir,String gameVersion, LoaderType loaderType, String loaderVersion, VersionManifest manifest){
 		String examplePackDir = "/packformat";
 		String packJsonPath = "mmc-pack.json";
 		String intermediaryJsonPath = "patches/net.fabricmc.intermediary.json";
 		String instanceCfgPath = "instance.cfg";
 		String iconPath = "ornithe.png";
+		String minecraftPatchPath = "patches/net.minecraft.json";
 
 		VersionManifest.Version version = manifest.getVersion(gameVersion);
-		VersionManifest.VersionDetails details = version.details();
-		String normalizedVersion = details.normalizedVersion();
-		Semver semver = new Semver(normalizedVersion);
-
 		String intermediaryVersion = version.id(GameSide.CLIENT);
-		String noAppletTrait = ""; // this is left empty and only filled in if the version is correct
-
-		if(semver.isLowerThan(VERSION_1_6)){
-			noAppletTrait = " \"+traits\": [\n" +
-					"    \t\"noapplet\"\n" +
-					"    ],";
-		}
 
 		try {
+			String lwjglVersion = findLwjglVersion(manifest, gameVersion);
+
 			String transformedPackJson = transformPackJson(
-					readResource(examplePackDir, packJsonPath), gameVersion, loaderType, loaderVersion, findLwjglVersion(manifest, gameVersion), intermediaryVersion
+					readResource(examplePackDir, packJsonPath), gameVersion, loaderType, loaderVersion, lwjglVersion, intermediaryVersion
 			);
 			String transformedIntermediaryJson = readResource(examplePackDir, intermediaryJsonPath)
 					.replaceAll("\\$\\{mc_version}", gameVersion)
-					.replaceAll("\\$\\{intermediary_ver}", intermediaryVersion)
-					.replaceAll("\\$\\{noapplet}", noAppletTrait);
+					.replaceAll("\\$\\{intermediary_ver}", intermediaryVersion);
+					//.replaceAll("\\$\\{noapplet}", noAppletTrait);
 
 			String transformedInstanceCfg = readResource(examplePackDir, instanceCfgPath)
 					.replaceAll("\\$\\{mc_version}", gameVersion);
+
+			String transformedMinecraftJson = transformMinecraftJson(
+					LaunchJson.getMmcJson(version).join(), lwjglVersion
+			);
 
 			if(IS_LINUX_LIKE_OS){
 				transformedInstanceCfg+= "\n" +"OverrideCommands=true" +"\n" + ENV_WRAPPER_COMMAND;
@@ -178,6 +180,7 @@ public class MmcPackCreator {
 			writeJsonToZip(zipOut, instanceCfgPath, transformedInstanceCfg);
 			writeJsonToZip(zipOut, intermediaryJsonPath, transformedIntermediaryJson);
 			writeJsonToZip(zipOut, packJsonPath, transformedPackJson);
+			writeJsonToZip(zipOut, minecraftPatchPath, transformedMinecraftJson);
 
 			zipOut.close();
 			fileOut.close();

--- a/src/main/java/org/quiltmc/installer/MmcPackCreator.java
+++ b/src/main/java/org/quiltmc/installer/MmcPackCreator.java
@@ -136,17 +136,15 @@ public class MmcPackCreator {
 		String instanceCfgPath = "instance.cfg";
 		String iconPath = "ornithe.png";
 
-		String noAppletTrait = ""; // this is left empty and only filled in if the version is correct
-		String intermediaryVersion = gameVersion;
-
-		VersionManifest.VersionDetails details = manifest.getVersion(gameVersion).details();
+		VersionManifest.Version version = manifest.getVersion(gameVersion);
+		VersionManifest.VersionDetails details = version.details();
 		String normalizedVersion = details.normalizedVersion();
-
 		Semver semver = new Semver(normalizedVersion);
+
+		String intermediaryVersion = version.id(GameSide.CLIENT);
+		String noAppletTrait = ""; // this is left empty and only filled in if the version is correct
+
 		if(semver.isLowerThan(VERSION_1_6)){
-			if(semver.isLowerThan(VERSION_1_3)){
-				intermediaryVersion+= "-client";
-			}
 			noAppletTrait = " \"+traits\": [\n" +
 					"    \t\"noapplet\"\n" +
 					"    ],";

--- a/src/main/java/org/quiltmc/installer/MmcPackCreator.java
+++ b/src/main/java/org/quiltmc/installer/MmcPackCreator.java
@@ -23,7 +23,10 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -115,6 +118,51 @@ public class MmcPackCreator {
 		return null;
 	}
 
+	private static Map<String, Object> getIntermediaryInfo(String gameVersion){
+		String rawUrl = OrnitheMeta.ORNITHE_META_URL + "/v3/versions/intermediary/" + gameVersion;
+
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				URL url = new URL(rawUrl);
+				URLConnection connection = Connections.openConnection(url);
+
+				InputStreamReader stream = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
+
+				try (BufferedReader reader = new BufferedReader(stream)) {
+					StringBuilder builder = new StringBuilder();
+					String line;
+
+					while ((line = reader.readLine()) != null) {
+						builder.append(line);
+						builder.append('\n');
+					}
+
+					return builder.toString();
+				}
+			} catch (IOException e) {
+				throw new UncheckedIOException(e); // Handled via .exceptionally(...)
+			}
+		}).thenApplyAsync(raw -> {
+			try {
+				//noinspection unchecked
+				List<Object> list = (List<Object>) Gsons.read(JsonReader.json(raw));
+				if (list == null || list.isEmpty()) {
+					throw new IOException("Invalid meta response");
+				}
+
+				Map<String, Object> map = (Map<String, Object>) list.get(0);
+
+				if(map.containsKey("maven") && map.containsKey("version")){
+					return map;
+				}else {
+					return null;
+				}
+			} catch (IOException e) {
+				throw new UncheckedIOException(e); // Handled via .exceptionally(...)
+			}
+		}).join();
+	}
+
 	private static String transformPackJson(String examplePackJson, String gameVersion, LoaderType type, String loaderVersion, String lwjglVersion, String intermediaryVersion){
 		String lwjglMajorVer = lwjglVersion.substring(0,1);
 		return examplePackJson
@@ -144,7 +192,9 @@ public class MmcPackCreator {
 		String minecraftPatchPath = "patches/net.minecraft.json";
 
 		VersionManifest.Version version = manifest.getVersion(gameVersion);
-		String intermediaryVersion = version.id(GameSide.CLIENT);
+		Map<String, Object> intermediaryInfo = getIntermediaryInfo(version.id(GameSide.CLIENT));
+		String intermediaryVersion = (String) intermediaryInfo.get("version");
+		String intermediaryMaven = (String) intermediaryInfo.get("maven");
 
 		try {
 			String lwjglVersion = findLwjglVersion(manifest, gameVersion);
@@ -154,8 +204,8 @@ public class MmcPackCreator {
 			);
 			String transformedIntermediaryJson = readResource(examplePackDir, intermediaryJsonPath)
 					.replaceAll("\\$\\{mc_version}", gameVersion)
-					.replaceAll("\\$\\{intermediary_ver}", intermediaryVersion);
-					//.replaceAll("\\$\\{noapplet}", noAppletTrait);
+					.replaceAll("\\$\\{intermediary_ver}", intermediaryVersion)
+					.replaceAll("\\$\\{intermediary_maven}", intermediaryMaven);
 
 			String transformedInstanceCfg = readResource(examplePackDir, instanceCfgPath)
 					.replaceAll("\\$\\{mc_version}", gameVersion);

--- a/src/main/java/org/quiltmc/installer/OrnitheMeta.java
+++ b/src/main/java/org/quiltmc/installer/OrnitheMeta.java
@@ -55,7 +55,6 @@ public final class OrnitheMeta {
 	 *
 	 * <p>The returned map has the version as the key and the maven artifact as the value
 	 */
-	// TODO: use
 	public static final Endpoint<Map<String, String>> INTERMEDIARY_VERSIONS_ENDPOINT = new Endpoint<>("/v3/versions/intermediary", reader -> {
 		Map<String, String> ret = new LinkedHashMap<>();
 

--- a/src/main/java/org/quiltmc/installer/VersionManifest.java
+++ b/src/main/java/org/quiltmc/installer/VersionManifest.java
@@ -241,6 +241,7 @@ public final class VersionManifest implements Iterable<VersionManifest.Version> 
 
 		List<String> manifests = null;
 		Boolean sharedMappings = null;
+		String normalizedVersion = null;
 
 		reader.beginObject();
 
@@ -262,6 +263,13 @@ public final class VersionManifest implements Iterable<VersionManifest.Version> 
 
 				sharedMappings = reader.nextBoolean();
 				break;
+			case "normalizedVersion":
+				if(reader.peek() != JsonToken.STRING) {
+					throw new ParseException("normalizedVersion must be a string", reader);
+				}
+
+				normalizedVersion = reader.nextString();
+				break;
 			default:
 				reader.skipValue();
 			}
@@ -271,8 +279,9 @@ public final class VersionManifest implements Iterable<VersionManifest.Version> 
 
 		if (manifests == null) throw new ParseException("manifests is required", reader);
 		if (sharedMappings == null) throw new ParseException("sharedMappings is required", reader);
+		if (normalizedVersion == null) throw new ParseException("normalizedVersion is required", reader);
 
-		return new VersionDetails(version, manifests, sharedMappings);
+		return new VersionDetails(version, normalizedVersion, manifests, sharedMappings);
 	}
 
 	private static List<String> readManifests(Version version, JsonReader reader) throws IOException, ParseException {
@@ -411,17 +420,23 @@ public final class VersionManifest implements Iterable<VersionManifest.Version> 
 
 	public static final class VersionDetails {
 		private final Version version;
+		private final String normalizedVersion;
 		private final List<String> manifests;
 		private final boolean sharedMappings;
 
-		VersionDetails(Version version, List<String> manifests, boolean sharedMappings) {
+		VersionDetails(Version version, String normalizedVersion, List<String> manifests, boolean sharedMappings) {
 			this.version = version;
+			this.normalizedVersion = normalizedVersion;
 			this.manifests = manifests;
 			this.sharedMappings = sharedMappings;
 		}
 
 		public Version version() {
 			return this.version;
+		}
+
+		public String normalizedVersion() {
+			return normalizedVersion;
 		}
 
 		public List<String> manifests() {

--- a/src/main/java/org/quiltmc/installer/action/Action.java
+++ b/src/main/java/org/quiltmc/installer/action/Action.java
@@ -90,8 +90,8 @@ public abstract class Action<M> {
 		return new ListVersions(loaderType, minecraftSnapshots, loaderBetas);
 	}
 
-	public static InstallClient installClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, @Nullable String installDir, boolean generateProfile) {
-		return new InstallClient(minecraftVersion, launcherType, loaderType, loaderVersion, installDir, generateProfile);
+	public static InstallClient installClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, @Nullable String installDir, boolean generateProfile) {
+		return new InstallClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, installDir, generateProfile);
 	}
 
 	public static InstallServer installServer(String minecraftVersion, LoaderType loaderType, @Nullable String loaderVersion, String installDir, boolean createScripts, boolean installServer) {

--- a/src/main/java/org/quiltmc/installer/action/InstallClient.java
+++ b/src/main/java/org/quiltmc/installer/action/InstallClient.java
@@ -48,15 +48,17 @@ public final class InstallClient extends Action<InstallClient.MessageType> {
 	private final LoaderType loaderType;
 	@Nullable
 	private final String loaderVersion;
+	private final String intermediary;
 	private final String installDir;
 	private final boolean generateProfile;
 	private Path installDirPath;
 
-	InstallClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String installDir, boolean generateProfile) {
+	InstallClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, String installDir, boolean generateProfile) {
 		this.minecraftVersion = minecraftVersion;
 		this.launcherType = launcherType;
 		this.loaderType = loaderType;
 		this.loaderVersion = loaderVersion;
+		this.intermediary = intermediary;
 		this.installDir = installDir;
 		this.generateProfile = generateProfile;
 	}
@@ -212,6 +214,7 @@ public final class InstallClient extends Action<InstallClient.MessageType> {
 					this.minecraftVersion,
 					this.loaderType,
 					this.loaderVersion,
+					this.intermediary,
 					installationInfo.manifest()
 			);
 		}).exceptionally(e -> {

--- a/src/main/java/org/quiltmc/installer/gui/swing/AbstractPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/AbstractPanel.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +53,7 @@ abstract class AbstractPanel extends JPanel {
 	@Nullable
 	private Map<LoaderType, List<String>> loaderVersions;
 	@Nullable
-	private Collection<String> intermediaryVersions;
+	private Map<String, String> intermediaryVersions;
 	protected boolean beaconOptOut = false;
 
 	AbstractPanel(SwingInstaller gui) {
@@ -69,7 +68,7 @@ abstract class AbstractPanel extends JPanel {
 		return rowPanel;
 	}
 
-	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Collection<String> intermediaryVersions) {
+	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Map<String, String> intermediaryVersions) {
 		this.manifest = manifest;
 		this.loaderVersions = loaderVersions;
 		this.intermediaryVersions = intermediaryVersions;
@@ -91,13 +90,13 @@ abstract class AbstractPanel extends JPanel {
 	}
 
 	@Nullable
-	public Collection<String> intermediaryVersions() {
+	public Map<String, String> intermediaryVersions() {
 		return this.intermediaryVersions;
 	}
 
 	abstract LoaderType loaderType();
 
-	static void populateMinecraftVersions(GameSide side, JComboBox<String> comboBox, VersionManifest manifest, Collection<String> intermediaryVersions, boolean snapshots) {
+	static void populateMinecraftVersions(GameSide side, JComboBox<String> comboBox, VersionManifest manifest, Map<String, String> intermediaryVersions, boolean snapshots) {
 		// Setup the combo box for Minecraft version selection
 		comboBox.removeAllItems();
 
@@ -108,7 +107,7 @@ abstract class AbstractPanel extends JPanel {
 				|| (version.type().equals("old_alpha") && snapshots)
 				|| (version.type().equals("alpha_server") && snapshots)
 				|| (version.type().equals("classic_server") && snapshots)) {
-				if (intermediaryVersions.contains(version.id(side))) {
+				if (intermediaryVersions.containsKey(version.id(side))) {
 					comboBox.addItem(version.id());
 				}
 			}

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -203,13 +203,14 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 		String loaderVersion = (String) this.loaderVersionSelector.getSelectedItem();
 		LauncherType launcherType = this.launcherType();
 		LoaderType loaderType = this.loaderType();
+		VersionManifest.Version version = this.manifest().getVersion(minecraftVersion);
 
 		Action<InstallClient.MessageType> action = Action.installClient(
 				minecraftVersion,
 				launcherType,
 				loaderType,
 				loaderVersion,
-				this.intermediaryVersions().get(minecraftVersion),
+				this.intermediaryVersions().get(version.id(GameSide.CLIENT)),
 				this.installLocation.getText(),
 				this.generateProfile
 		);

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -46,7 +46,7 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 	private final JCheckBox showLoaderBetasCheckBox;
 	private final JTextField installLocation;
 	private final JButton selectInstallationLocation;
-	private JComponent telemetryCheckBox;
+	//private JComponent telemetryCheckBox;
 	private JCheckBox generateProfileCheckBox;
 	private final JButton installButton;
 	private boolean showSnapshots;
@@ -128,9 +128,6 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 				if (this.loaderVersions() != null) {
 					populateLoaderVersions(GameSide.CLIENT, this.loaderVersionSelector, this.loaderVersions(this.loaderType()), this.showLoaderBetas);
 				}
-				if (telemetryCheckBox != null) {
-					telemetryCheckBox.setVisible(this.loaderType() == LoaderType.QUILT);
-				}
 			});
 		}
 
@@ -167,13 +164,6 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 			});
 			this.generateProfile = true;
 			this.generateProfileCheckBox = generateProfileBox;
-
-
-			JCheckBox optOutBox = new JCheckBox(Localization.get("gui.beacon-opt-out"), null, true);
-			row5.add(optOutBox);
-			optOutBox.setEnabled(false);
-			optOutBox.setVisible(false);
-			this.telemetryCheckBox = optOutBox;
 		}
 
 		// Install button

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -19,7 +19,6 @@ package org.quiltmc.installer.gui.swing;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -200,14 +199,17 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 
 
 	private void install(ActionEvent event) {
+		String minecraftVersion = (String) this.minecraftVersionSelector.getSelectedItem();
+		String loaderVersion = (String) this.loaderVersionSelector.getSelectedItem();
 		LauncherType launcherType = this.launcherType();
 		LoaderType loaderType = this.loaderType();
 
 		Action<InstallClient.MessageType> action = Action.installClient(
-				(String) this.minecraftVersionSelector.getSelectedItem(),
+				minecraftVersion,
 				launcherType,
 				loaderType,
-				(String) this.loaderVersionSelector.getSelectedItem(),
+				loaderVersion,
+				this.intermediaryVersions().get(minecraftVersion),
 				this.installLocation.getText(),
 				this.generateProfile
 		);
@@ -236,7 +238,7 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallClient.
 	}
 
 	@Override
-	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Collection<String> intermediaryVersions) {
+	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Map<String, String> intermediaryVersions) {
 		super.receiveVersions(manifest, loaderVersions, intermediaryVersions);
 
 		populateMinecraftVersions(GameSide.CLIENT, this.minecraftVersionSelector, manifest, intermediaryVersions, this.showSnapshots);

--- a/src/main/java/org/quiltmc/installer/gui/swing/ServerPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ServerPanel.java
@@ -20,7 +20,6 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.nio.file.*;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -178,7 +177,7 @@ final class ServerPanel extends AbstractPanel implements Consumer<InstallServer.
 	}
 
 	@Override
-	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Collection<String> intermediaryVersions) {
+	void receiveVersions(VersionManifest manifest, Map<LoaderType, List<String>> loaderVersions, Map<String, String> intermediaryVersions) {
 		super.receiveVersions(manifest, loaderVersions, intermediaryVersions);
 
 		populateMinecraftVersions(GameSide.SERVER, this.minecraftVersionSelector, manifest, intermediaryVersions, this.showSnapshots);

--- a/src/main/java/org/quiltmc/installer/gui/swing/SwingInstaller.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/SwingInstaller.java
@@ -82,7 +82,7 @@ public final class SwingInstaller extends JFrame {
 						return !(v.startsWith("0.16.0-beta.") && v.length() == 13 && v.charAt(12) != '9');
 					}).collect(Collectors.toList()));
 				}
-				Collection<String> intermediaryVersions = quiltMeta.getEndpoint(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT).keySet();
+				Map<String, String> intermediaryVersions = quiltMeta.getEndpoint(OrnitheMeta.INTERMEDIARY_VERSIONS_ENDPOINT);
 
 				this.clientPanel.receiveVersions(manifest, loaderVersions, intermediaryVersions);
 				this.serverPanel.receiveVersions(manifest, loaderVersions, intermediaryVersions);

--- a/src/main/resources/packformat/mmc-pack.json
+++ b/src/main/resources/packformat/mmc-pack.json
@@ -29,7 +29,7 @@
                     "uid": "net.minecraft"
                 }
             ],
-            "cachedVersion": "${mc_version}",
+            "cachedVersion": "${intermediary_ver}",
             "dependencyOnly": true,
             "uid": "net.fabricmc.intermediary",
             "version": "${mc_version}"

--- a/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
+++ b/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
@@ -2,10 +2,11 @@
     "formatVersion": 1,
     "libraries": [
         {
-            "name": "net.ornithemc:calamus-intermediary:${mc_version}",
+            "name": "net.ornithemc:calamus-intermediary:${intermediary_ver}",
             "url": "https://maven.ornithemc.net/releases"
         }
     ],
+    ${noapplet}
     "name": "Intermediary Mappings",
     "requires": [
         {
@@ -15,5 +16,5 @@
     ],
     "type": "release",
     "uid": "net.fabricmc.intermediary",
-    "version": "${mc_version}"
+    "version": "${intermediary_ver}"
 }

--- a/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
+++ b/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
@@ -6,7 +6,6 @@
             "url": "https://maven.ornithemc.net/releases"
         }
     ],
-    ${noapplet}
     "name": "Intermediary Mappings",
     "requires": [
         {

--- a/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
+++ b/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
@@ -2,7 +2,7 @@
     "formatVersion": 1,
     "libraries": [
         {
-            "name": "net.ornithemc:calamus-intermediary:${intermediary_ver}",
+            "name": "${intermediary_maven}",
             "url": "https://maven.ornithemc.net/releases"
         }
     ],

--- a/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
+++ b/src/main/resources/packformat/patches/net.fabricmc.intermediary.json
@@ -2,7 +2,7 @@
     "formatVersion": 1,
     "libraries": [
         {
-            "name": "${intermediary_maven}",
+            "name": "${intermediary_maven}:${intermediary_ver}",
             "url": "https://maven.ornithemc.net/releases"
         }
     ],


### PR DESCRIPTION
Issues
- [x] add noapplet trait to versions below 1.6
- [x] add "-client" to the intermediary version for versions below 1.3
- [x] fix issues with version name mismatches between our manifests and the manifests MMC/Prism uses  

Also I am really confused with the module system and don't know how to add a dependency to the module so this PR is not merge-able at all currently