### PR TITLE
add option to not generate patches for common libraries

### DIFF
--- a/src/main/java/org/quiltmc/installer/CliInstaller.java
+++ b/src/main/java/org/quiltmc/installer/CliInstaller.java
@@ -151,7 +151,7 @@ public final class CliInstaller {
 
 				// At this point all the require arguments have been parsed
 				if (split.size() == 0) {
-					return Action.installClient(minecraftVersion, launcherType, loaderType, null, intermediary, null, false, false);
+					return Action.installClient(minecraftVersion, launcherType, loaderType, null, intermediary, null, false, false, true);
 				}
 
 				// Try to parse loader version first
@@ -166,7 +166,7 @@ public final class CliInstaller {
 
 				// No more arguments, just loader version
 				if (split.size() == 0) {
-					return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, null, false, false);
+					return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, null, false, false, true);
 				}
 
 				// There are some additional options
@@ -193,7 +193,12 @@ public final class CliInstaller {
 						}
 
 						options.put("--copy-profile-path", null);
+					} else if (option.equals("--no-extra-libraries")) {
+						if (options.containsKey("--no-extra-libraries")) {
+							System.err.println("Encountered duplicate option \"--no-extra-libraries\", This shouldn't affect anything");
+						}
 
+						options.put("--no-extra-libraries", null);
 					} else if (option.equals("--disable-beacon")) {
 						if (options.containsKey("--disable-beacon")) {
 							System.err.println("Encountered duplicate option \"--disable-beacon\", This shouldn't affect anything");
@@ -231,7 +236,7 @@ public final class CliInstaller {
 					}
 				}
 
-				return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, options.get("--install-dir"), !options.containsKey("--no-profile"), options.containsKey("--copy-profile-path"));
+				return Action.installClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, options.get("--install-dir"), !options.containsKey("--no-profile"), options.containsKey("--copy-profile-path"), options.containsKey("--no-extra-libraries"));
 			}
 			case "server": {
 				if (split.size() < 1) {

--- a/src/main/java/org/quiltmc/installer/LaunchJson.java
+++ b/src/main/java/org/quiltmc/installer/LaunchJson.java
@@ -37,10 +37,10 @@ public final class LaunchJson {
 		return LaunchJson.get(gameVersion).thenApply(
 				vanillaJson ->  {
 					try {
-						Map<String, Object> vanilaMap = (Map<String, Object>) Gsons.read(JsonReader.json(vanillaJson));
+						Map<String, Object> vanillaMap = (Map<String, Object>) Gsons.read(JsonReader.json(vanillaJson));
 
 						String clientName = "com.mojang:minecraft:" + gameVersion.id() + ":client";
-						Map<String,Map<String, String>> downloads = (Map<String, Map<String, String>>) vanilaMap.get("downloads");
+						Map<String,Map<String, String>> downloads = (Map<String, Map<String, String>>) vanillaMap.get("downloads");
 						Map<String, String> client = downloads.get("client");
 
 						Map<String, Object> mainJar = Map.of(
@@ -48,20 +48,20 @@ public final class LaunchJson {
 								"name",clientName
 						);
 
-						List<Map<String, String>> vanillaLibraries = (List<Map<String, String>>) vanilaMap.get("libraries");
+						List<Map<String, String>> vanillaLibraries = (List<Map<String, String>>) vanillaMap.get("libraries");
 						vanillaLibraries.removeIf(lib -> {
 							String name = lib.get("name");
 							return name.contains("org.ow2.asm") || name.contains("org.lwjgl");
 						});
 
 						List<String> traits = new ArrayList<>();
-						if (((String) vanilaMap.get("mainClass")).contains("launchwrapper")) {
+						if (((String) vanillaMap.get("mainClass")).contains("launchwrapper")) {
 							traits.add("texturepacks");
 						}
 
-						String minecraftArguments = (String) vanilaMap.getOrDefault("minecraftArguments", "");
-						if (vanilaMap.containsKey("arguments")) {
-							Map<String, Object> arguments =  ((Map<String, Object>) vanilaMap.get("arguments"));//.get("game");
+						String minecraftArguments = (String) vanillaMap.getOrDefault("minecraftArguments", "");
+						if (vanillaMap.containsKey("arguments")) {
+							Map<String, Object> arguments =  ((Map<String, Object>) vanillaMap.get("arguments"));//.get("game");
 
 							if(!arguments.isEmpty()){
 								List<Object> gameArguments = (List<Object>) arguments.get("game");
@@ -85,7 +85,7 @@ public final class LaunchJson {
 						Gsons.write(
 								JsonWriter.json(writer),
 								buildPackJsonMap(
-										vanilaMap, vanillaLibraries, minecraftArguments, traits, mainJar, gameVersion.id()
+										vanillaMap, vanillaLibraries, minecraftArguments, traits, mainJar, gameVersion.id()
 								)
 						);
 

--- a/src/main/java/org/quiltmc/installer/MmcPackCreator.java
+++ b/src/main/java/org/quiltmc/installer/MmcPackCreator.java
@@ -181,7 +181,7 @@ public class MmcPackCreator {
 
 	}
 
-	public static void compileMmcZip(Path outPutDir, String gameVersion, LoaderType loaderType, String loaderVersion, String intermediaryInfo, VersionManifest manifest, boolean copyProfilePath) {
+	public static void compileMmcZip(Path outPutDir, String gameVersion, LoaderType loaderType, String loaderVersion, String intermediaryInfo, VersionManifest manifest, boolean copyProfilePath, boolean addCommonLibraries) {
 
 		String examplePackDir = "/packformat";
 		String packJsonPath = "mmc-pack.json";
@@ -226,14 +226,19 @@ public class MmcPackCreator {
 				Files.createDirectory(fs.getPath("patches"));
 				Files.writeString(fs.getPath(intermediaryJsonPath), transformedIntermediaryJson);
 				Files.writeString(fs.getPath(minecraftPatchPath), transformedMinecraftJson);
-				String packJsonWithLibraries = addCommonLibraries(fs.getPath("/"), intermediaryVersion,
-						loaderType, loaderVersion, transformedPackJson);
-
-				Files.writeString(fs.getPath(packJsonPath), packJsonWithLibraries);
+				String finalPackJson;
+				if (addCommonLibraries) {
+					finalPackJson = addCommonLibraries(fs.getPath("/"), intermediaryVersion,
+							loaderType, loaderVersion, transformedPackJson);
+				} else {
+					finalPackJson = transformedPackJson;
+				}
+				Files.writeString(fs.getPath(packJsonPath), finalPackJson);
 			}
 
 			if (copyProfilePath) {
-				Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(zipFile.toString()), null);
+				StringSelection path = new StringSelection(zipFile.toString());
+				Toolkit.getDefaultToolkit().getSystemClipboard().setContents(path, path);
 			}
 
 		} catch (IOException e) {

--- a/src/main/java/org/quiltmc/installer/action/Action.java
+++ b/src/main/java/org/quiltmc/installer/action/Action.java
@@ -90,8 +90,8 @@ public abstract class Action<M> {
 		return new ListVersions(loaderType, minecraftSnapshots, loaderBetas);
 	}
 
-	public static InstallClient installClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, @Nullable String installDir, boolean generateProfile, boolean copyProfilePath) {
-		return new InstallClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, installDir, generateProfile, copyProfilePath);
+	public static InstallClient installClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, @Nullable String installDir, boolean generateProfile, boolean copyProfilePath, boolean addCommonLibraries) {
+		return new InstallClient(minecraftVersion, launcherType, loaderType, loaderVersion, intermediary, installDir, generateProfile, copyProfilePath, addCommonLibraries);
 	}
 
 	public static InstallServer installServer(String minecraftVersion, LoaderType loaderType, @Nullable String loaderVersion, String installDir, boolean createScripts, boolean installServer) {

--- a/src/main/java/org/quiltmc/installer/action/InstallClient.java
+++ b/src/main/java/org/quiltmc/installer/action/InstallClient.java
@@ -52,9 +52,10 @@ public final class InstallClient extends Action<InstallMessageType> {
 	private final String installDir;
 	private final boolean generateProfile;
 	private final boolean copyProfilePath;
+	private final boolean addCommonLibraries;
 	private Path installDirPath;
 
-	InstallClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, String installDir, boolean generateProfile, boolean copyProfilePath) {
+	InstallClient(String minecraftVersion, LauncherType launcherType, LoaderType loaderType, @Nullable String loaderVersion, String intermediary, String installDir, boolean generateProfile, boolean copyProfilePath, boolean addCommonLibraries) {
 		this.minecraftVersion = minecraftVersion;
 		this.launcherType = launcherType;
 		this.loaderType = loaderType;
@@ -63,6 +64,7 @@ public final class InstallClient extends Action<InstallMessageType> {
 		this.installDir = installDir;
 		this.generateProfile = generateProfile;
 		this.copyProfilePath = copyProfilePath;
+		this.addCommonLibraries = addCommonLibraries;
 	}
 
 	@Override
@@ -218,7 +220,8 @@ public final class InstallClient extends Action<InstallMessageType> {
 					this.loaderVersion,
 					this.intermediary,
 					installationInfo.manifest(),
-					this.copyProfilePath
+					this.copyProfilePath,
+					this.addCommonLibraries
 			);
 			statusTracker.accept(InstallMessageType.SUCCEED);
 		}).exceptionally(e -> {

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -49,11 +49,13 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallMessage
 	//private JComponent telemetryCheckBox;
 	private JCheckBox generateProfileCheckBox;
 	private JCheckBox copyProfilePathCheckBox;
+	private JCheckBox addCommonLibrariesCheckBox;
 	private final JButton installButton;
 	private boolean showSnapshots;
 	private boolean showLoaderBetas;
 	private boolean generateProfile;
 	private boolean copyProfilePath;
+	private boolean addCommonLibraries;
 
 	ClientPanel(SwingInstaller gui) {
 		super(gui);
@@ -167,9 +169,13 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallMessage
 			this.generateProfile = true;
 			this.generateProfileCheckBox = generateProfileBox;
 
-			row5.add(copyProfilePathCheckBox = new JCheckBox(Localization.get("gui.client.copy-profile-to-clipboard"), null, true)).setVisible(false);
-			copyProfilePathCheckBox.addItemListener(e -> this.copyProfilePath = e.getStateChange() == ItemEvent.SELECTED);
+			row5.add(this.copyProfilePathCheckBox = new JCheckBox(Localization.get("gui.client.copy-profile-to-clipboard"), null, true)).setVisible(false);
+			this.copyProfilePathCheckBox.addItemListener(e -> this.copyProfilePath = e.getStateChange() == ItemEvent.SELECTED);
 			this.copyProfilePath = true;
+
+			row5.add(this.addCommonLibrariesCheckBox = new JCheckBox(Localization.get("gui.client.add-common-libraries"), null, true)).setVisible(false);
+			addCommonLibrariesCheckBox.addItemListener(e -> this.addCommonLibraries = e.getStateChange() == ItemEvent.SELECTED);
+			this.addCommonLibraries = true;
 		}
 
 		// Install button
@@ -189,12 +195,14 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallMessage
 				case OFFICIAL:
 					this.generateProfileCheckBox.setVisible(true);
 					this.copyProfilePathCheckBox.setVisible(false);
+					this.addCommonLibrariesCheckBox.setVisible(false);
 					this.installLocation.setText(OsPaths.getDefaultInstallationDir().toString());
 					this.installButton.setText(Localization.get("gui.install"));
 					break;
 				case MULTIMC:
 					this.generateProfileCheckBox.setVisible(false);
 					this.copyProfilePathCheckBox.setVisible(true);
+					this.addCommonLibrariesCheckBox.setVisible(true);
 					this.installButton.setText(Localization.get("gui.install.mmc"));
 					this.installLocation.setText(System.getProperty("user.dir"));
 					break;
@@ -222,7 +230,8 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallMessage
 				this.intermediaryVersions().get(version.id(GameSide.CLIENT)),
 				this.installLocation.getText(),
 				this.generateProfile,
-				this.copyProfilePath
+				this.copyProfilePath,
+				this.addCommonLibraries
 		);
 
 		AtomicReference<InstallMessageType> result = new AtomicReference<>();

--- a/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/ClientPanel.java
@@ -169,6 +169,7 @@ final class ClientPanel extends AbstractPanel implements Consumer<InstallMessage
 
 			row5.add(copyProfilePathCheckBox = new JCheckBox(Localization.get("gui.client.copy-profile-to-clipboard"), null, true)).setVisible(false);
 			copyProfilePathCheckBox.addItemListener(e -> this.copyProfilePath = e.getStateChange() == ItemEvent.SELECTED);
+			this.copyProfilePath = true;
 		}
 
 		// Install button

--- a/src/main/resources/lang/en-US.usage
+++ b/src/main/resources/lang/en-US.usage
@@ -33,6 +33,8 @@ where install options for only the client also include:
                   Prevents you from counting towards the monthly user statistics
    --copy-profile-path
                   Copies the profile path to the clipboard if generating a MultiMC instance
+   --no-extra-libraries
+                  If generating a MultiMC profile, do not add common libraries from later versions of minecraft
 
 where install options for only the server also include:
 

--- a/src/main/resources/lang/installer.properties
+++ b/src/main/resources/lang/installer.properties
@@ -22,6 +22,7 @@ gui.server.download.server=Download server jar
 gui.server.generate-script=Generate launch script
 gui.client.generate-profile=Generate profile
 gui.client.copy-profile-to-clipboard=Copy Profile Path to Clipboard
+gui.client.add-common-libraries=Add Common Libraries
 gui.install.loading=Loading...
 gui.install=Install
 gui.install.mmc=Generate Pack


### PR DESCRIPTION
good for testing if you don't want to rely on these libraries, or you want to stick closer to vanilla for whatever reason (speedrunning, etc)
libraries are added by default, this just lets the user disable that