### PR TITLE
Fix Long Refresh Times

### DIFF
--- a/src/main/java/org/quiltmc/installer/gui/swing/AbstractPanel.java
+++ b/src/main/java/org/quiltmc/installer/gui/swing/AbstractPanel.java
@@ -98,7 +98,7 @@ abstract class AbstractPanel extends JPanel {
 						|| (version.type().equals("old_alpha") && snapshots)
 						|| (version.type().equals("alpha_server") && snapshots)
 						|| (version.type().equals("classic_server") && snapshots))
-				.filter(version -> intermediaryVersions.containsKey(version.id(side)))
+				.filter(version -> intermediaryVersions.containsKey(version.id()) || intermediaryVersions.containsKey(version.id() + "-" + side.id()))
 				.map(VersionManifest.Version::id).forEachOrdered(comboBox::addItem);
 
 		comboBox.setEnabled(true);


### PR DESCRIPTION
Fixes the insane load times when launching the installer, and especially from switching to snapshots.

Tested with server and client, both show their proper things still.

![image](https://github.com/user-attachments/assets/3d683146-60a3-41ce-8e17-be97bfcc6a26)
![image](https://github.com/user-attachments/assets/40827e4a-c0dd-4661-9f0b-261e2c1c77eb)
